### PR TITLE
fix gulpfile copy img

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ gulp.task("copy:html", function() {
 });
 
 gulp.task("copy:img", function() {
-  return gulp.src("./src/img/*").pipe(gulp.dest("./build/img"));
+  return gulp.src("./src/img/**/*").pipe(gulp.dest("./build/img"));
 });
 
 gulp.task("serv", function() {


### PR DESCRIPTION
solves issue with empty img subfolders in build
